### PR TITLE
Create an alpine based version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM marvinbuss/aml-docker:1.10.0
+FROM marvinbuss/aml-docker:1.10.0-alpine
 
 LABEL maintainer="azure/gh-aml"
 


### PR DESCRIPTION
This version mirrors v1.10.0 but uses the alpine base image underneath. 